### PR TITLE
fix exec argv

### DIFF
--- a/grails
+++ b/grails
@@ -35,4 +35,4 @@ if [ ! -x "$GRAILS_CMD" ]; then
 	exit 3
 fi
 
-exec $GRAILS_CMD $*
+exec $GRAILS_CMD "$@"


### PR DESCRIPTION
`"$@"` is like `"$1" "$2" ...` which handles whitespace in the arguments e.g. if somebody called it as `grails 'foo bar'` -- probably not too likely but this is a standard shell idiom
